### PR TITLE
Create open orders page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5299,6 +5299,63 @@
         "@aws-amplify/xr": "2.2.16"
       }
     },
+    "aws-sdk": {
+      "version": "2.824.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.824.0.tgz",
+      "integrity": "sha512-9KNRQBkIMPn+6DWb4gR+RzqTMNyGLEwOgXbE4dDehOIAflfLnv3IFwLnzrhxJnleB4guYrILIsBroJFBzjiekg==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -12792,6 +12849,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jquery": {
       "version": "3.5.1",
@@ -20875,6 +20937,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4794,6 +4794,19 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz",
+      "integrity": "sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4879,6 +4892,18 @@
             "json5": "^1.0.1"
           }
         }
+      }
+    },
+    "airtable": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.10.1.tgz",
+      "integrity": "sha512-obFW+R3ly2mKtCj0D/xto0ggUvYwdM0RJT3VJ9wvgqoxDkzqg2mNtkuTNfYjF6wWQA0GvoHG9guqzgBBqFjItw==",
+      "requires": {
+        "@types/node": ">=8.0.0 <15",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "^4.17.19",
+        "node-fetch": "^2.6.1"
       }
     },
     "ajv": {
@@ -8952,6 +8977,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
     "@tinymce/tinymce-react": "^3.3.2",
+    "airtable": "^0.10.1",
     "aws-amplify": "^3.3.13",
     "bootstrap": "^4.3.1",
     "bosket": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tinymce/tinymce-react": "^3.3.2",
     "airtable": "^0.10.1",
     "aws-amplify": "^3.3.13",
+    "aws-sdk": "^2.824.0",
     "bootstrap": "^4.3.1",
     "bosket": "^0.2.3",
     "brace": "^0.11.1",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,11 +8,23 @@ import SettingsPanel from './shared/SettingsPanel';
 import Footer from './shared/Footer';
 import { withTranslation } from "react-i18next";
 import Amplify, { Auth } from 'aws-amplify';
+
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);
 
+
+Amplify.configure({
+    API: {
+        endpoints: [
+            {
+                name: "w4madata",
+                endpoint: "https://xce0pika3a.execute-api.us-east-1.amazonaws.com/prod"
+            }
+        ]
+    }
+});
 
 class App extends Component {
   state = {}

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -17,7 +17,6 @@ Amplify.configure(awsconfig);
 class App extends Component {
   state = {}
   componentDidMount() {
-    console.log("aws config====>", awsconfig);
     this.onRouteChanged();
   }
 
@@ -39,7 +38,7 @@ class App extends Component {
               <AppRoutes/>
               { SettingsPanelComponent }
             </div>
-              { footerComponent }   
+              { footerComponent }
           </div>
         </div>
       </div>

--- a/src/app/shared/SettingsPanel.js
+++ b/src/app/shared/SettingsPanel.js
@@ -6,7 +6,7 @@ export class SettingsPanel extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { 
+    this.state = {
         todos: [
             {
                 id: 1,
@@ -111,7 +111,7 @@ addTodo (event) {
         id: todos.length ? todos[todos.length - 1].id + 1 : 1,
         task: this.state.inputValue,
         isCompleted: false
-        
+
     })
 
     this.setState({
@@ -127,7 +127,7 @@ addTodoRtl (event) {
       id: todosRtl.length ? todosRtl[todosRtl.length - 1].id + 1 : 1,
       task: this.state.inputValue,
       isCompleted: false
-      
+
   })
 
   this.setState({
@@ -179,11 +179,11 @@ inputChangeHandler(event) {
                       <div>
                         <h4 className="card-title"><Trans>Todo List</Trans></h4>
                         <form  className="add-items d-flex" onSubmit={this.addTodo}>
-                          <input 
-                            type="text" 
-                            className="form-control h-auto" 
-                            placeholder="What do you need to do today?" 
-                            value={this.state.inputValue} 
+                          <input
+                            type="text"
+                            className="form-control h-auto"
+                            placeholder="What do you need to do today?"
+                            value={this.state.inputValue}
                             onChange={this.inputChangeHandler}
                             required />
                           <button type="submit" className="btn btn-primary font-weight-bold"><Trans>Add</Trans></button>
@@ -191,7 +191,7 @@ inputChangeHandler(event) {
                         <div className="list-wrapper">
                           <ul className="todo-list">
                             {this.state.todos.map((todo, index) =>{
-                              return <ListItem 
+                              return <ListItem
                               isCompleted={todo.isCompleted}
                               changed={(event) => this.statusChangedHandler(event, index)}
                               key={todo.id}
@@ -201,7 +201,7 @@ inputChangeHandler(event) {
                           </ul>
                           <ul className="todo-list rtl-todo">
                             {this.state.todosRtl.map((todoRtl, index) =>{
-                              return <ListItem 
+                              return <ListItem
                               isCompleted={todoRtl.isCompleted}
                               changed={(event) => this.statusChangedHandler(event, index)}
                               key={todoRtl.id}
@@ -300,14 +300,14 @@ inputChangeHandler(event) {
   }
 }
 const ListItem = (props) => {
-    
+
   return (
       <li className={(props.isCompleted ? 'completed' : null)}>
           <div className="form-check">
-              <label htmlFor="" className="form-check-label"> 
-                  <input className="checkbox" type="checkbox" 
-                      checked={props.isCompleted} 
-                      onChange={props.changed} 
+              <label htmlFor="" className="form-check-label">
+                  <input className="checkbox" type="checkbox"
+                      checked={props.isCompleted}
+                      onChange={props.changed}
                       /> {props.children} <i className="input-helper"></i>
               </label>
           </div>

--- a/src/app/shared/SettingsPanel.js
+++ b/src/app/shared/SettingsPanel.js
@@ -6,7 +6,7 @@ export class SettingsPanel extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {
+    this.state = { 
         todos: [
             {
                 id: 1,
@@ -111,7 +111,7 @@ addTodo (event) {
         id: todos.length ? todos[todos.length - 1].id + 1 : 1,
         task: this.state.inputValue,
         isCompleted: false
-
+        
     })
 
     this.setState({
@@ -127,7 +127,7 @@ addTodoRtl (event) {
       id: todosRtl.length ? todosRtl[todosRtl.length - 1].id + 1 : 1,
       task: this.state.inputValue,
       isCompleted: false
-
+      
   })
 
   this.setState({
@@ -179,11 +179,11 @@ inputChangeHandler(event) {
                       <div>
                         <h4 className="card-title"><Trans>Todo List</Trans></h4>
                         <form  className="add-items d-flex" onSubmit={this.addTodo}>
-                          <input
-                            type="text"
-                            className="form-control h-auto"
-                            placeholder="What do you need to do today?"
-                            value={this.state.inputValue}
+                          <input 
+                            type="text" 
+                            className="form-control h-auto" 
+                            placeholder="What do you need to do today?" 
+                            value={this.state.inputValue} 
                             onChange={this.inputChangeHandler}
                             required />
                           <button type="submit" className="btn btn-primary font-weight-bold"><Trans>Add</Trans></button>
@@ -191,7 +191,7 @@ inputChangeHandler(event) {
                         <div className="list-wrapper">
                           <ul className="todo-list">
                             {this.state.todos.map((todo, index) =>{
-                              return <ListItem
+                              return <ListItem 
                               isCompleted={todo.isCompleted}
                               changed={(event) => this.statusChangedHandler(event, index)}
                               key={todo.id}
@@ -201,7 +201,7 @@ inputChangeHandler(event) {
                           </ul>
                           <ul className="todo-list rtl-todo">
                             {this.state.todosRtl.map((todoRtl, index) =>{
-                              return <ListItem
+                              return <ListItem 
                               isCompleted={todoRtl.isCompleted}
                               changed={(event) => this.statusChangedHandler(event, index)}
                               key={todoRtl.id}
@@ -300,14 +300,14 @@ inputChangeHandler(event) {
   }
 }
 const ListItem = (props) => {
-
+    
   return (
       <li className={(props.isCompleted ? 'completed' : null)}>
           <div className="form-check">
-              <label htmlFor="" className="form-check-label">
-                  <input className="checkbox" type="checkbox"
-                      checked={props.isCompleted}
-                      onChange={props.changed}
+              <label htmlFor="" className="form-check-label"> 
+                  <input className="checkbox" type="checkbox" 
+                      checked={props.isCompleted} 
+                      onChange={props.changed} 
                       /> {props.children} <i className="input-helper"></i>
               </label>
           </div>

--- a/src/app/shared/Sidebar.js
+++ b/src/app/shared/Sidebar.js
@@ -128,7 +128,7 @@ class Sidebar extends Component {
             </div>
             <Collapse in={ this.state.tablesMenuOpen }>
               <ul className="nav flex-column sub-menu">
-                <li className="nav-item"> <Link className={ this.isPathActive('/tables/basic-table') ? 'nav-link active' : 'nav-link' } to="/tables/basic-table"><Trans>Basic Table</Trans></Link></li>
+                <li className="nav-item"> <Link className={ this.isPathActive('/tables/basic-table') ? 'nav-link active' : 'nav-link' } to="/tables/basic-table"><Trans>All Open Orders</Trans></Link></li>
               </ul>
             </Collapse>
           </li>

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -11,7 +11,7 @@ export class OpenOrdersTable extends Component {
 
   async getAirtableOrders() {
 
-    const apiName = 'w4madata'; //'w4madata'; // FIXME
+    const apiName = 'w4madata'; // FIXME
     const path = '/orders';
     const myInit = { // OPTIONAL
         response: true, // OPTIONAL (return the entire Axios response object instead of only response.data)
@@ -23,19 +23,15 @@ export class OpenOrdersTable extends Component {
     const orders = await API
       .get(apiName, path, myInit)
       .then(response => {
-        // Add your code here
-        console.log("======= response: ======", response)
-        return response
+        console.log("retrieved response from airtable")
+        return response.data.body.records
       })
       .catch(error => {
-        console.log("^^^^^^^^^^^^^^^ errror", error)
+        console.log("ERROR RETRIEVING DATA", error)
         console.log(error.response);
      });
 
     this.setState({orders})
-    /*const orders = await base("orders").select().all()
-      .then( r => {return r});
-    this.setState({orders});*/
   }
 
   async componentDidMount(){
@@ -47,10 +43,26 @@ export class OpenOrdersTable extends Component {
   render() {
 
     const {orders} = this.state
-    // const {orders} =  {orders: [123]}
-    return (
-      JSON.stringify(orders)
-    )
+
+    return
+
+
+    orders.map((x, index) => (
+
+      <tr>
+        <td>{x.fields.id}</td>
+        <td>{x.fields.first_name}</td>
+        <td>{x.fields.delivery_date}</td>
+        <td>{x.fields.language}</td>
+        <td>
+          <i className="input-helper"></i>
+        </td>
+        <td><label className="badge badge-warning">{x.fields.order_status}</label></td>
+
+        <td><a href="/order/xxx" target="_blank"> <i className="mdi mdi-open-in-new"></i></a></td>
+      </tr>
+
+    ));
   }
 }
 

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -30,6 +30,7 @@ export class OpenOrdersTable extends Component {
 
     client.getSecretValue({SecretId: secretName}, function(err, data){
       if (err) {
+        console.log("===== ISSA ERROR ====", err)
         throw err;
       } else {
         console.log("===== SECRET DATA ====", data)
@@ -62,13 +63,14 @@ export class OpenOrdersTable extends Component {
 
   async componentDidMount(){
 
-    // await this.fetchAirtable()
+    await this.fetchAirtable()
 
   }
 
   render() {
 
-    const {orders} = {orders: [123]}// this.state
+    const {orders} = this.state
+    // const {orders} =  {orders: [123]}
     return (
       JSON.stringify(orders)
     )

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -44,6 +44,28 @@ export class OpenOrdersTable extends Component {
 
     const {orders} = this.state
 
+    // create the table rows in a loop
+    let tableRows = []
+    let order
+    for (var i = 0; i < orders.length; i++) {
+        order = orders[i].fields
+
+        tableRows.push(
+          <tr>
+            <td>{order.order_id}</td>
+            <td>{order.first_name}</td>
+            <td>{order.delivery_date}</td>
+            <td>{order.language}</td>
+            <td>
+              <i className="input-helper"></i>
+            </td>
+            <td><label className="badge badge-warning">{order.order_status}</label></td>
+
+            <td><a href={"/order/" + order.order_id} target="_blank"> <i className="mdi mdi-open-in-new"></i></a></td>
+          </tr>
+          )
+          ;
+    }
     return (
 
       <div>
@@ -69,22 +91,8 @@ export class OpenOrdersTable extends Component {
                       </tr>
                     </thead>
                     <tbody>
-                      {orders.map((x, index) => (
-                        <tr>
-                          <td>{x.fields.id}</td>
-                          <td>{x.fields.first_name}</td>
-                          <td>{x.fields.delivery_date}</td>
-                          <td>{x.fields.language}</td>
-                          <td>
-                            <i className="input-helper"></i>
-                          </td>
-                          <td><label className="badge badge-warning">{x.fields.order_status}</label></td>
-
-                          <td><a href="/order/xxx" target="_blank"> <i className="mdi mdi-open-in-new"></i></a></td>
-                        </tr>
-
-                        ))}
-                        </tbody>
+                    {tableRows}
+                    </tbody>
                  </table>
                </div>
              </div>

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -1,72 +1,55 @@
 import React, { Component } from 'react'
 import { ProgressBar } from 'react-bootstrap';
-
-
-// TODO store the API key in aws secrets manager
-/*
-// Load the AWS SDK
-var AWS = require('aws-sdk'),
-    region = "us-east-1",
-    secretName = "airtable/credentials/apiKey",
-    secret,
-    decodedBinarySecret;
-
-// Create a Secrets Manager client
-var client = new AWS.SecretsManager({
-    region: region
-});
-
-// In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
-// See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-// We rethrow the exception by default.
-
-client.getSecretValue({SecretId: secretName}, function(err, data) {
-    if (err) {
-        if (err.code === 'DecryptionFailureException')
-            // Secrets Manager can't decrypt the protected secret text using the provided KMS key.
-            // Deal with the exception here, and/or rethrow at your discretion.
-            throw err;
-        else if (err.code === 'InternalServiceErrorException')
-            // An error occurred on the server side.
-            // Deal with the exception here, and/or rethrow at your discretion.
-            throw err;
-        else if (err.code === 'InvalidParameterException')
-            // You provided an invalid value for a parameter.
-            // Deal with the exception here, and/or rethrow at your discretion.
-            throw err;
-        else if (err.code === 'InvalidRequestException')
-            // You provided a parameter value that is not valid for the current state of the resource.
-            // Deal with the exception here, and/or rethrow at your discretion.
-            throw err;
-        else if (err.code === 'ResourceNotFoundException')
-            // We can't find the resource that you asked for.
-            // Deal with the exception here, and/or rethrow at your discretion.
-            throw err;
-    }
-    else {
-        // Decrypts secret using the associated KMS CMK.
-        // Depending on whether the secret is a string or binary, one of these fields will be populated.
-        if ('SecretString' in data) {
-            secret = data.SecretString;
-        } else {
-            let buff = new Buffer(data.SecretBinary, 'base64');
-            decodedBinarySecret = buff.toString('ascii');
-        }
-    }
-
-    // Your code goes here.
-});
-
-*/
+import awsmobile from '../../aws-exports';
 
 export class OpenOrdersTable extends Component {
   state = {
     orders: []
   }
+
+  async getAirtableApiKey() {
+    // Load the AWS SDK
+    var AWS = require('aws-sdk')
+
+    AWS.config.update({
+      region: awsmobile.aws_cognito_region,
+      credentials: new AWS.CognitoIdentityCredentials({
+        IdentityPoolId: awsmobile.aws_cognito_identity_pool_id
+      })
+    });
+
+    var region = "us-east-1"
+    var secretName = "airtable/credentials/apiKey"
+    var secret
+    var decodedBinarySecret;
+
+    // Create a Secrets Manager client
+    var client = new AWS.SecretsManager({
+        region: region
+    });
+
+    client.getSecretValue({SecretId: secretName}, function(err, data){
+      if (err) {
+        throw err;
+      } else {
+        console.log("===== SECRET DATA ====", data)
+          // Decrypts secret using the associated KMS CMK.
+          // Depending on whether the secret is a string or binary, one of these fields will be populated.
+          if ('SecretString' in data) {
+              return data.SecretString;
+          } else {
+              let buff = new Buffer(data.SecretBinary, 'base64');
+              return buff.toString('ascii');
+          }
+      }
+    })
+
+  }
+
   async fetchAirtable() {
     var Airtable = require('airtable');
-    var apiKey = "XXXXXXXXX" // FIXME
-
+    var apiKey = await this.getAirtableApiKey()
+    console.log("got apiKey", apiKey)
     Airtable.configure({ apiKey: apiKey })
 
     console.log("=== componentDidMount === ")
@@ -79,13 +62,13 @@ export class OpenOrdersTable extends Component {
 
   async componentDidMount(){
 
-    await this.fetchAirtable()
+    // await this.fetchAirtable()
 
   }
 
   render() {
 
-    const {orders} = this.state
+    const {orders} = {orders: [123]}// this.state
     return (
       JSON.stringify(orders)
     )

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -9,6 +9,7 @@ export class OpenOrdersTable extends Component {
 
   async getAirtableApiKey() {
     // Load the AWS SDK
+    return "keyqGCcOtMdZa7szl" // FIXME DO NOT COMMIT !!
     var AWS = require('aws-sdk')
 
     AWS.config.update({
@@ -30,7 +31,7 @@ export class OpenOrdersTable extends Component {
 
     client.getSecretValue({SecretId: secretName}, function(err, data){
       if (err) {
-        console.log("===== ISSA ERROR ====", err)
+        console.log("===== ERROR GETTING SECRET ====", err)
         throw err;
       } else {
         console.log("===== SECRET DATA ====", data)

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -1,70 +1,46 @@
 import React, { Component } from 'react'
 import { ProgressBar } from 'react-bootstrap';
 import awsmobile from '../../aws-exports';
+import { API } from 'aws-amplify';
 
 export class OpenOrdersTable extends Component {
   state = {
     orders: []
   }
 
-  async getAirtableApiKey() {
-    // Load the AWS SDK
-    return "keyqGCcOtMdZa7szl" // FIXME DO NOT COMMIT !!
-    var AWS = require('aws-sdk')
 
-    AWS.config.update({
-      region: awsmobile.aws_cognito_region,
-      credentials: new AWS.CognitoIdentityCredentials({
-        IdentityPoolId: awsmobile.aws_cognito_identity_pool_id
+  async getAirtableOrders() {
+
+    const apiName = 'w4madata'; //'w4madata'; // FIXME
+    const path = '/orders';
+    const myInit = { // OPTIONAL
+        response: true, // OPTIONAL (return the entire Axios response object instead of only response.data)
+        queryStringParameters: {  // OPTIONAL
+            key1: 'value1',
+        },
+    };
+
+    const orders = await API
+      .get(apiName, path, myInit)
+      .then(response => {
+        // Add your code here
+        console.log("======= response: ======", response)
+        return response
       })
-    });
+      .catch(error => {
+        console.log("^^^^^^^^^^^^^^^ errror", error)
+        console.log(error.response);
+     });
 
-    var region = "us-east-1"
-    var secretName = "airtable/credentials/apiKey"
-    var secret
-    var decodedBinarySecret;
-
-    // Create a Secrets Manager client
-    var client = new AWS.SecretsManager({
-        region: region
-    });
-
-    client.getSecretValue({SecretId: secretName}, function(err, data){
-      if (err) {
-        console.log("===== ERROR GETTING SECRET ====", err)
-        throw err;
-      } else {
-        console.log("===== SECRET DATA ====", data)
-          // Decrypts secret using the associated KMS CMK.
-          // Depending on whether the secret is a string or binary, one of these fields will be populated.
-          if ('SecretString' in data) {
-              return data.SecretString;
-          } else {
-              let buff = new Buffer(data.SecretBinary, 'base64');
-              return buff.toString('ascii');
-          }
-      }
-    })
-
-  }
-
-  async fetchAirtable() {
-    var Airtable = require('airtable');
-    var apiKey = await this.getAirtableApiKey()
-    console.log("got apiKey", apiKey)
-    Airtable.configure({ apiKey: apiKey })
-
-    console.log("=== componentDidMount === ")
-    var base = Airtable.base('appMSgZejI6f64OwM');
-
-    const orders = await base("orders").select().all()
+    this.setState({orders})
+    /*const orders = await base("orders").select().all()
       .then( r => {return r});
-    this.setState({orders});
+    this.setState({orders});*/
   }
 
   async componentDidMount(){
 
-    await this.fetchAirtable()
+    await this.getAirtableOrders()
 
   }
 

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -44,10 +44,7 @@ export class OpenOrdersTable extends Component {
 
     const {orders} = this.state
 
-    return
-
-
-    orders.map((x, index) => (
+    return orders.map((x, index) => (
 
       <tr>
         <td>{x.fields.id}</td>

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -44,22 +44,56 @@ export class OpenOrdersTable extends Component {
 
     const {orders} = this.state
 
-    return orders.map((x, index) => (
+    return (
 
-      <tr>
-        <td>{x.fields.id}</td>
-        <td>{x.fields.first_name}</td>
-        <td>{x.fields.delivery_date}</td>
-        <td>{x.fields.language}</td>
-        <td>
-          <i className="input-helper"></i>
-        </td>
-        <td><label className="badge badge-warning">{x.fields.order_status}</label></td>
+      <div>
+        <div className="row">
 
-        <td><a href="/order/xxx" target="_blank"> <i className="mdi mdi-open-in-new"></i></a></td>
-      </tr>
+          <div className="col-lg-12 grid-margin stretch-card">
+            <div className="card">
+              <div className="card-body">
+                <h4 className="card-title">In-progress Orders</h4>
+                <p className="card-description">All open orders that have not yet been delivered
+                </p>
+                <div className="table-responsive">
+                <table className="table table-hover">
+                <thead>
+                      <tr>
+                        <th>Id</th>
+                        <th>Name</th>
+                        <th>Delivery Date</th>
+                        <th>Language</th>
+                        <th>Urgent</th>
+                        <th>Order status</th>
+                        <th>View order</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {orders.map((x, index) => (
+                        <tr>
+                          <td>{x.fields.id}</td>
+                          <td>{x.fields.first_name}</td>
+                          <td>{x.fields.delivery_date}</td>
+                          <td>{x.fields.language}</td>
+                          <td>
+                            <i className="input-helper"></i>
+                          </td>
+                          <td><label className="badge badge-warning">{x.fields.order_status}</label></td>
 
-    ));
+                          <td><a href="/order/xxx" target="_blank"> <i className="mdi mdi-open-in-new"></i></a></td>
+                        </tr>
+
+                        ))}
+                        </tbody>
+                 </table>
+               </div>
+             </div>
+           </div>
+         </div>
+
+       </div>
+     </div>
+    );
   }
 }
 

--- a/src/app/tables/BasicTable.js
+++ b/src/app/tables/BasicTable.js
@@ -11,9 +11,9 @@ export class OpenOrdersTable extends Component {
 
   async getAirtableOrders() {
 
-    const apiName = 'w4madata'; // FIXME
+    const apiName = 'w4madata';
     const path = '/orders';
-    const myInit = { // OPTIONAL
+    const apiParameters = { // OPTIONAL parameters
         response: true, // OPTIONAL (return the entire Axios response object instead of only response.data)
         queryStringParameters: {  // OPTIONAL
             key1: 'value1',
@@ -21,7 +21,7 @@ export class OpenOrdersTable extends Component {
     };
 
     const orders = await API
-      .get(apiName, path, myInit)
+      .get(apiName, path, apiParameters)
       .then(response => {
         console.log("retrieved response from airtable")
         return response.data.body.records


### PR DESCRIPTION
Closes #12 

Looks like this, and is connected to airtable! 


<img width="1287" alt="Screen Shot 2021-02-14 at 5 27 36 PM" src="https://user-images.githubusercontent.com/6672955/107891028-265d8d80-6eea-11eb-8405-32ba974dbd39.png">


The live link is [here](https://main.d3imjaeqoyytyk.amplifyapp.com/) - first make an account, and then go to Tables > All Open Orders. 

It's connected to my personal airtable account, so these are just dummy orders. If you change something in airtable, it will be reflected on our website (just hit refresh).

### how it works

Our airtable API key is safely locked away inside of our AWS account, so no one who views our site will be able to ever see our airtable API key. 

I made an AWS Lambda function called getAirtableOrders (code [here](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/getAirtableOrders?tab=configuration)), and I store the airtable API key right there in the lambda. There is probably a fancier way than this, but eh, this was easy, and I ran into issues trying to store the API key in AWS secrets manager. It just means we'll have to write the API key in any lambda function we make, but we should only need a handful of lambdas. (Ideally we could do something like [this](https://aws.amazon.com/blogs/security/how-to-securely-provide-database-credentials-to-lambda-functions-by-using-aws-secrets-manager/) I think).

The lambda function forms the airtable API request following as specified by [these docs](https://airtable.com/appMSgZejI6f64OwM/api/docs#curl/table:orders:list)

Here is the code for the lambda (with the `api_key` and `base_name` redacted):
```py
import json
from botocore.vendored import requests


def lambda_handler(event, context):
    api_key = "####"
    headers = {"Authorization": "Bearer {}".format(api_key)}
    base_name = "####"
    table_name = "orders"
    view_name = "order_view"
    max_records = 2000
    url = "https://api.airtable.com/v0/{}/{}?maxRecords={}&view={}".format(base_name, table_name, max_records, view_name)
    result = requests.get(url, headers=headers)
    
    return {
        "statusCode": 200,
        "headers": {
            "Access-Control-Allow-Credentials": True,
            "Access-Control-Allow-Headers": "Content-Type",
            "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
            "Access-Control-Allow-Origin": "*",
        },
        "body": result.json()
    }
```


Once the lambda is created, I make a AWS API gateway api, with a GET method that calls this lambda: see [here](https://console.aws.amazon.com/apigateway/home?region=us-east-1#/apis/xce0pika3a/resources/hggf8w/methods/GET). Looks like this:
<img width="1172" alt="Screen Shot 2021-02-14 at 5 42 00 PM" src="https://user-images.githubusercontent.com/6672955/107891361-2b234100-6eec-11eb-82f1-8ab63d2f46cc.png">



The reason I'm kind of "wrapping" the airtable lambda in an AWS lambda is because our web app is built with AWS so it has all the credentials it needs to access an AWS API gateway api. Specifically what that means is I can just have a couple lines of code like this in my application, without worrying about authentication:

https://github.com/ward4mutualaid-data/w4madata/blob/236a152109605b1f840653be203d343c94e9545c/src/app/tables/BasicTable.js#L14-L32


